### PR TITLE
Read server's ISUPPORT and get prefix there

### DIFF
--- a/application/src/main/java/org/jibble/pircbot/PircBot.java
+++ b/application/src/main/java/org/jibble/pircbot/PircBot.java
@@ -1000,6 +1000,8 @@ public abstract class PircBot implements ReplyConstants {
 
     StringTokenizer tokenizer = new StringTokenizer(line);
     String senderInfo = tokenizer.nextToken();
+    if (senderInfo.startsWith("@"))
+      senderInfo = tokenizer.nextToken();
     String command = tokenizer.nextToken();
     String target = null;
 


### PR DESCRIPTION
Also stores the ISUPPORT parameters in an easily accessible HashMap and fixes a slight parsing bug with IRCv3 message tags